### PR TITLE
Enable auto generate release note setting for release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,7 +6,8 @@
   },
   "github": {
     "release": true,
-    "releaseName": "${npm.name}@${version}"
+    "releaseName": "${npm.name}@${version}",
+    "autoGenerate": true
   },
   "hooks": {
     "after:bump": "npm run build"


### PR DESCRIPTION
release-itでGitHub Release Noteを作成する際にGitHubの自動生成機能を使うようにします。
https://github.com/release-it/release-it/blob/main/docs/github-releases.md#configuration-options