### PR TITLE
jsx-runtimeを同梱しないようにviteの設定を変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@serendie/symbols",
       "version": "0.0.10",
+      "license": "MIT",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig(({ command }) => {
           formats: ["es"],
         },
         rollupOptions: {
-          external: ["react", "react-dom"],
+          external: ["react", "react-dom", "react/jsx-runtime"],
           output: {
             preserveModules: true,
             preserveModulesRoot: "src",


### PR DESCRIPTION
ビルド時にJSXランタイムが同梱されていたため、バージョンの違うReactが同居しているとランタイムエラーが発生してしまっていました。

### 今後の進め方

- mainにマージして @serendie/symbols をリリース
- @serendie/ui で使用している @serendie/symbols をアップデート
- @serendie/ui をリリース
- 必要なモジュールそれぞれで@serendie/uiをアップデート